### PR TITLE
refactor: use `process.env.HOME` for consistent home path retrieval

### DIFF
--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -48,7 +48,7 @@ export function getFoldersBasePath(): string {
   if (!foldersBasePath || !folderExists) {
     let homePath = "";
     if (os === "darwin" || os === "linux") {
-      homePath = cp.execSync(`echo $HOME`).toString().replace("\r\r", "").replace("\n", "");
+      homePath = process.env.HOME ?? "";
     } else if (os.toLowerCase().startsWith("win")) {
       folderName = "ParallelsDesktop";
       homePath = process.env.APPDATA ?? "";


### PR DESCRIPTION
# Description

Addresses an issue where the retrieval of the home path was inconsistent across
different operating systems in the `getFoldersBasePath` function.

## Summary

- Replaced <code>cp.execSync(\`echo $HOME\`)</code> with `process.env.HOME` to retrieve the home path.
- Removed unnecessary string manipulation that `replace()`s on `"\r\r"` and `"\n"`.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test) that prove my fix is effective or that my feature works
- [x] I have run format check (npm run format-check) that shows any code inconsistency
- [x] I have updated the CHANGELOG.md file accordingly
