### PR TITLE
Fix remote catalog refresh issue

### DIFF
--- a/src/tree/commands/devopsRemoteHostProvider/removeRemoteProvider.ts
+++ b/src/tree/commands/devopsRemoteHostProvider/removeRemoteProvider.ts
@@ -25,7 +25,7 @@ const registerDevOpsRemoveRemoteProviderHostCommand = (
       }
 
       const config = Provider.getConfiguration();
-      const providerId = item.id.split("%%")[0];
+      const providerId = item.id.split("%%")[1];
       const provider = config.findRemoteHostProviderById(providerId);
       if (!provider) {
         ShowErrorMessage(TELEMETRY_DEVOPS_REMOTE, `Remote Host Provider ${item.name} not found`);


### PR DESCRIPTION
# Description

- Fixed an issue where if a remote host was down the auto-refresh would not work as intended

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test) that prove my fix is effective or that my feature works
- [x] I have run format check (npm run format-check) that shows any code inconsistency
- [x] I have updated the CHANGELOG.md file accordingly
