### PR TITLE
Release version 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "parallels-desktop" extension will be documented in this file.
 
+## [1.5.1] - 2025-02-13
+
+- Fixed an issue where the right click would show options not available for each machine, fixes #158 
+- Fixed an issue with detecting new devops service versions
+- Added the ability to notify discord users about new versions
+
 ## [1.5.0] - 2025-01-14
 
 - Added new icon designs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "parallels-desktop",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "parallels-desktop",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "dependencies": {
                 "@amplitude/analytics-node": "^1.3.6",
                 "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/Parallels/parallels-vscode-extension"
   },
   "icon": "img/logo/parallels_logo.png",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "engines": {
     "vscode": "^1.90.0"
   },

--- a/src/constants/flags.ts
+++ b/src/constants/flags.ts
@@ -1,4 +1,4 @@
-export const VERSION = "1.5.0";
+export const VERSION = "1.5.1";
 export const FLAG_NO_GROUP = "no_group";
 export const FLAG_OS = "parallels-desktop:os";
 export const FLAG_CONFIGURATION = "parallels.configuration";


### PR DESCRIPTION
# Release 1.5.1

- Fixed an issue where the right click would show options not available for each machine, fixes #158 
- Fixed an issue with detecting new devops service versions
- Added the ability to notify discord users about new versions
