### PR TITLE
Release version 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to the "parallels-desktop" extension will be documented in t
 - Fixed an issue where the tree was getting stuck on refresh
 - Fixed an issue where the extension would fail to start if devops was updated
 - Fixed an issue when displaying error messages
+- Fixed an issue where the tree was getting stuck on refresh
+- Fixed an issue where the extension would fail to start if devops was updated
+- Fixed an issue when displaying error messages
 
 ## [1.5.1] - 2025-02-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parallels-desktop",
-  "version": "1.5.4",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parallels-desktop",
-      "version": "1.5.4",
+      "version": "1.5.2",
       "dependencies": {
         "@amplitude/analytics-node": "^1.3.8",
         "axios": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/Parallels/parallels-vscode-extension"
   },
   "icon": "img/logo/parallels_logo.png",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "engines": {
     "vscode": "^1.99.0"
   },

--- a/src/constants/flags.ts
+++ b/src/constants/flags.ts
@@ -1,4 +1,4 @@
-export const VERSION = "1.5.4";
+export const VERSION = "1.5.2";
 export const FLAG_NO_GROUP = "no_group";
 export const FLAG_OS = "parallels-desktop:os";
 export const FLAG_CONFIGURATION = "parallels.configuration";


### PR DESCRIPTION
# Release 1.5.2

- Fixed an issue where the tree was getting stuck on refresh
- Fixed an issue where the extension would fail to start if devops was updated
- Fixed an issue when displaying error messages
