### PR TITLE
Release version 1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "parallels-desktop" extension will be documented in this file.
 
+## [1.5.4] - 2025-08-26
+
+- Eliminated the sunset AI package prompt from initialization.
+- Removed configuration options and related logic for the sunset AI package.
+- Deleted all commands and services associated with the Parallels Catalog, including refresh, pull manifest, and onboarding commands.
+- Cleaned up the ParallelsCatalogProvider and its associated methods.
+- Updated configuration service to remove references to the sunset AI package.
+
 ## [1.5.3] - 2025-07-22
 
 - Added the new message for the sunset of the PD AI package

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parallels-desktop",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parallels-desktop",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "dependencies": {
         "@amplitude/analytics-node": "^1.3.8",
         "axios": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/Parallels/parallels-vscode-extension"
   },
   "icon": "img/logo/parallels_logo.png",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "engines": {
     "vscode": "^1.102.0"
   },

--- a/src/constants/flags.ts
+++ b/src/constants/flags.ts
@@ -1,4 +1,4 @@
-export const VERSION = "1.5.3";
+export const VERSION = "1.5.4";
 export const FLAG_NO_GROUP = "no_group";
 export const FLAG_OS = "parallels-desktop:os";
 export const FLAG_CONFIGURATION = "parallels.configuration";


### PR DESCRIPTION
# Release 1.5.4

- Eliminated the sunset AI package prompt from initialization.
- Removed configuration options and related logic for the sunset AI package.
- Deleted all commands and services associated with the Parallels Catalog, including refresh, pull manifest, and onboarding commands.
- Cleaned up the ParallelsCatalogProvider and its associated methods.
- Updated configuration service to remove references to the sunset AI package.
